### PR TITLE
shallow clone for building

### DIFF
--- a/.github/workflows/hatch-publish-to-pypi.yml
+++ b/.github/workflows/hatch-publish-to-pypi.yml
@@ -19,7 +19,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          submodules: 'recursive'
 
       - name: Set up Python
         uses: actions/setup-python@v4


### PR DESCRIPTION
Building failed with recursive submodules -- could not find the test data.
Since the test data is not necessary for building or publishing: I removed the recursive cloning.